### PR TITLE
chore: mini-css-extract-plugin を 2.10.2 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "css-loader": "^6.8.1",
         "html-webpack-plugin": "^5.5.3",
         "jest": "^29.5.0",
-        "mini-css-extract-plugin": "^2.7.6",
+        "mini-css-extract-plugin": "^2.10.2",
         "postcss": "^8.4.24",
         "postcss-loader": "^7.3.3",
         "prettier": "^2.8.8",
@@ -8412,9 +8412,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.1.tgz",
-      "integrity": "sha512-k7G3Y5QOegl380tXmZ68foBRRjE9Ljavx835ObdvmZjQ639izvZD8CS7BkWw1qKPPzHsGL/JDhl0uyU1zc2rJw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.2.tgz",
+      "integrity": "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "css-loader": "^6.8.1",
     "html-webpack-plugin": "^5.5.3",
     "jest": "^29.5.0",
-    "mini-css-extract-plugin": "^2.7.6",
+    "mini-css-extract-plugin": "^2.10.2",
     "postcss": "^8.4.24",
     "postcss-loader": "^7.3.3",
     "prettier": "^2.8.8",


### PR DESCRIPTION
## 概要
- `mini-css-extract-plugin` を `2.10.1` から `2.10.2` へ更新しました。

## 変更内容
- `package.json` の依存バージョン更新
- `package-lock.json` の更新

## 動作確認
- `npm test` : 成功
- `npm run build` : 成功

## 補足
- 同リポジトリのメジャー更新候補として `webpack-cli` の更新も検証しましたが、`npm run build` が `--node-env` 非対応エラーで失敗したため、今回のPRには含めていません（別途見送り）。