### PR TITLE
chore: prettier を v3 系へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "mini-css-extract-plugin": "^2.7.6",
         "postcss": "^8.4.24",
         "postcss-loader": "^7.3.3",
-        "prettier": "^2.8.8",
+        "prettier": "^3.8.1",
         "tailwindcss": "^3.3.2",
         "webpack": "^5.88.1",
         "webpack-cli": "^5.1.4",
@@ -9352,16 +9352,16 @@
       "license": "MIT"
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mini-css-extract-plugin": "^2.7.6",
     "postcss": "^8.4.24",
     "postcss-loader": "^7.3.3",
-    "prettier": "^2.8.8",
+    "prettier": "^3.8.1",
     "tailwindcss": "^3.3.2",
     "webpack": "^5.88.1",
     "webpack-cli": "^5.1.4",


### PR DESCRIPTION
## 概要
- `prettier` を `2.8.8` から `3.8.1` へメジャーアップデートしました。
- メジャー更新ルールに従い、このPRは `prettier` のみを更新しています。

## 変更ログ / Breaking Changes 確認
- 参照: https://prettier.io/blog/2023/07/05/3.0.0.html
- 主要な破壊的変更として以下を確認しました。
  - `trailingComma` のデフォルトが `es5` から `all` に変更
  - プラグインAPIの変更（ESM / async parser 対応）
- 本リポジトリでは Prettier のプラグインを利用していないため、影響は限定的と判断しています。

## 検証
- `npm test` : 成功
- `npm run build` : 成功

CI が成功することを確認後にマージします。
