### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,16 @@
 version: 2
+multi-ecosystem-groups:
+  dependency-updates:
+    schedule:
+      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependency-updates"
+    groups:
+      all-npm-security-updates:
+        applies-to: "security-updates"
+        patterns: ["*"]
     cooldown:
       default-days: 2


### PR DESCRIPTION
### Motivation
- Reduce Dependabot noise by grouping related dependency updates (especially npm) and consolidating security updates so fewer, larger PRs are opened.

### Description
- Added a `multi-ecosystem-groups` entry with a weekly `dependency-updates` group and updated the `npm` update entry to use `patterns: ["*"]`, `multi-ecosystem-group: "dependency-updates"`, and a `groups.all-npm-security-updates` group applying to `security-updates` with `patterns: ["*"]`, while keeping `cooldown.default-days: 2` in `.github/dependabot.yml`.

### Testing
- Validated the new YAML and grouping settings with a Ruby one-liner that loads `.github/dependabot.yml` and checks the expected keys and values, which succeeded; and ran `git diff --check`, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b7fa5d9c8326bbd20b75ccf46be9)