### PR TITLE
.npmrc に min-release-age=7 を追加

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 registry=https://npm.flatt.tech
+
+min-release-age=7


### PR DESCRIPTION
### Motivation
- npm の最小リリースエイジが未設定だったため、リリース頻度を制御する目的でプロジェクトに `min-release-age=7` を設定します。

### Description
- `.npmrc` に `min-release-age=7` を追記しました（変更ファイル: `.npmrc`）。

### Testing
- 自動テストとして `npm config get min-release-age --location=project` が `7` を返し、`npm test -- --runInBand` は成功しましたが、`npm run build` は既存の `webpack-cli` が `--node-env=production` を未知のオプションとして扱うため失敗しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044d223c8483268ee07cdc4586f66b)