### PR TITLE
CIで最新Node.js LTSを使用するワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push: {}
+  pull_request: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+


### PR DESCRIPTION
### Motivation
- CIで常に最新のNode.js LTSを使うことでローカルとの乖離を減らし、テストの安定性を向上させる目的です。

### Description
- 新しいGitHub Actionsワークフローを追加しました（`.github/workflows/ci.yml`）。
- `actions/setup-node@v4` を使い `node-version: lts/*` を指定して最新LTSを使用するようにしました。
- ワークフローは `push` と `pull_request` で走り、`npm ci` と `npm test` を実行します。
- `npm` キャッシュを有効にするために `cache: npm` を設定しました。

### Testing
- ローカルで `npm ci` を実行して依存関係のインストールを確認しました（成功）。
- ローカルで `npm test` を実行し、`jest` のテストが全て成功しました（2スイート、8テスト、すべて通過）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04527ae0f48326837210cc722da845)