### PR TITLE
Dependabot設定を更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,34 @@
 version: 2
-multi-ecosystem-groups:
-  dependency-updates:
-    schedule:
-      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    patterns: ["*"]
-    multi-ecosystem-group: "dependency-updates"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 60
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-npm-security-updates:
         applies-to: "security-updates"
-        patterns: ["*"]
-    cooldown:
-      default-days: 2
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    groups:
+      all-github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
### Motivation
- npm と GitHub Actions の依存関係更新を週次で管理し、不要なマイナー/パッチ更新のPRを抑えてノイズを減らすために設定を整理しました。
- 重要なセキュリティ更新をグループ化して迅速に対応できるようにするためです。

### Description
- `.github/dependabot.yml` を `updates` ブロックに置き換え、`npm` と `github-actions` を明示的に追加しました。
- 両エコシステムで `schedule: weekly` を設定しました。
- `cooldown` を追加して `default-days: 7` と `semver-major-days: 60` を設定しました。
- `ignore` でマイナー/パッチの通常更新を除外し、セキュリティ更新を `groups` でまとめる設定を追加しました。

### Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "YAML OK"'` を実行してYAML構文チェックは成功しました。
- `git diff --check` を実行して差分チェックは問題ありませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b219b8b4083269e2bc667f82ed70c)